### PR TITLE
Use a class to represent the IUCN filename format to allow for validation

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,10 @@
 
 * Validated compatibility with pandas 3, so updated requirements list.
 
+### Fixed
+
+* Fixed species-richness and endemism scripts to use the new IUCN format filenames.
+
 ## v2.1.1 (18/03/2026)
 
 ### Changed

--- a/aoh/__init__.py
+++ b/aoh/__init__.py
@@ -15,6 +15,7 @@ import tomli as tomllib
 from .cleaning import tidy_data
 from ._internal.aoh_fractional import aohcalc_fractional
 from ._internal.aoh_binary import aohcalc_binary
+from ._internal.utils import IUCNFormatFilename
 
 try:
     from importlib import metadata

--- a/aoh/_internal/speciesinfo.py
+++ b/aoh/_internal/speciesinfo.py
@@ -6,6 +6,8 @@ from pathlib import Path
 import geopandas as gpd
 import pandas as pd
 
+from .utils import IUCNFormatFilename
+
 def load_crosswalk_table(table_file_name: Path) -> dict[str,list[int]]:
     rawdata = pd.read_csv(table_file_name)
     result : dict[str,list[int]] = {}
@@ -86,19 +88,9 @@ class SpeciesInfo:
             raise ValueError(self.manifest["error"]) from exc
 
     def filenames(self, output_directory_path: Path) -> tuple[Path,Path]:
-        species_id_part = f"T{self.species_id}"
-        assessment_id = self.assessment_id
-        assessment_id_part = f"A{assessment_id}" if assessment_id is not None else ""
-
-        season = self.season
-        seasonality_part = f"_{season}" if season is not None else ""
-
-        stem = f"aoh_{species_id_part}{assessment_id_part}{seasonality_part}"
-
-        result_filename = output_directory_path / f"{stem}.tif"
-        manifest_filename = output_directory_path / f"{stem}.json"
-
-        return result_filename, manifest_filename
+        raster_filename = IUCNFormatFilename("aoh", self.species_id, self.assessment_id, self.season, ".tif")
+        json_filename = IUCNFormatFilename("aoh", self.species_id, self.assessment_id, self.season, ".json")
+        return output_directory_path / raster_filename.to_path(), output_directory_path / json_filename.to_path()
 
     def save_manifest(self, output_directory_path:Path, error_message: str | None = None) -> None:
         _, manifest_filename = self.filenames(output_directory_path)

--- a/aoh/_internal/utils.py
+++ b/aoh/_internal/utils.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+# \w technically will gobble underscores, but that's okay
+# as we're explicit about the underscores around the taxon/assessment ids
+PATTERN = re.compile(r"^(\w+)_T(\d+)(?:A(\d+))?(?:_(\w+))?$")
+
+@dataclass
+class IUCNFormatFilename:
+    """This class represents the naming scheme used by the IUCN Redlist Website for filetypes."""
+
+    content: str
+    taxon_id: int
+    assessment_id: int | None
+    season: str | None
+    suffix: str
+
+    @classmethod
+    def of_filename(cls, filename: Path | str) -> IUCNFormatFilename:
+        typed_filename = Path(filename)
+        name = typed_filename.stem
+        match = PATTERN.match(name)
+        if match is None:
+            raise ValueError("Filename did not match expected format")
+        parts = match.groups()
+        return cls(
+            content = parts[0],
+            taxon_id = int(parts[1]),
+            assessment_id = int(parts[2]) if parts[2] is not None else None,
+            season = parts[3],
+            suffix = typed_filename.suffix,
+        )
+
+    def to_path(self) -> Path:
+        assessment = f"A{self.assessment_id}" if self.assessment_id is not None else ""
+        season = f"_{self.season}" if self.season is not None else ""
+        return Path(f"{self.content}_T{self.taxon_id}{assessment}{season}{self.suffix}")

--- a/aoh/summaries/endemism.py
+++ b/aoh/summaries/endemism.py
@@ -17,6 +17,8 @@ from osgeo import gdal # type: ignore
 from yirgacheffe.layers import RasterLayer # type: ignore
 import yirgacheffe.operators as yo # type: ignore
 
+from .. import IUCNFormatFilename
+
 def geometric_sum(raster: RasterLayer) -> Optional[RasterLayer]:
     aoh = raster.sum()
     if aoh > 0.0:
@@ -136,9 +138,10 @@ def endemism(
     aohs = list(aohs_dir.glob("**/*.tif"))
     print(f"We found {len(aohs)} AoH rasters")
 
-    species_rasters : Dict[str,Set[Path]] = {}
+    species_rasters : Dict[int,Set[Path]] = {}
     for raster_path in aohs:
-        speciesid = raster_path.name.split('_')[0]
+        parts = IUCNFormatFilename.of_filename(raster_path)
+        speciesid = parts.taxon_id
         species_rasters[speciesid] = species_rasters.get(speciesid, set()).union({raster_path})
     print(f"Species detected: {len(species_rasters)} ")
 

--- a/aoh/summaries/species_richness.py
+++ b/aoh/summaries/species_richness.py
@@ -10,6 +10,8 @@ from pathlib import Path
 
 import yirgacheffe as yg
 
+from .. import IUCNFormatFilename
+
 def stage_1_worker(
     filename: str,
     result_dir: str,
@@ -66,9 +68,10 @@ def species_richness(
     aohs = list(Path(aohs_dir).rglob('*.tif'))
     print(f"We found {len(list(aohs))} AoH rasters")
 
-    species_rasters : dict[str,set[Path]] = {}
+    species_rasters : dict[int,set[Path]] = {}
     for raster_path in aohs:
-        speciesid = raster_path.name.split('_')[0]
+        parts = IUCNFormatFilename.of_filename(raster_path)
+        speciesid = parts.taxon_id
         species_rasters[speciesid] = species_rasters.get(speciesid, set()).union({raster_path})
     print(f"Species detected: {len(species_rasters)} ")
 

--- a/tests/test_filename.py
+++ b/tests/test_filename.py
@@ -1,0 +1,41 @@
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from aoh import IUCNFormatFilename
+
+@pytest.mark.parametrize("filename, expected", [
+    ("aoh_T42A123_all.tif", IUCNFormatFilename("aoh", 42, 123, "all", ".tif")),
+    (Path("aoh_T42A123_all.tif"), IUCNFormatFilename("aoh", 42, 123, "all", ".tif")),
+    ("/test/directory/aoh_T42A123_all.tif", IUCNFormatFilename("aoh", 42, 123, "all", ".tif")),
+    (Path("/test/directory/aoh_T42A123_all.tif"), IUCNFormatFilename("aoh", 42, 123, "all", ".tif")),
+    ("aoh_T42A123_all.json", IUCNFormatFilename("aoh", 42, 123, "all", ".json")),
+    ("aoh_T42A123_vår.json", IUCNFormatFilename("aoh", 42, 123, "vår", ".json")),
+    (Path("aoh_T42A123_vår.json"), IUCNFormatFilename("aoh", 42, 123, "vår", ".json")),
+    ("aoh_T42A123.tif", IUCNFormatFilename("aoh", 42, 123, None, ".tif")),
+    ("aoh_T42_all.tif", IUCNFormatFilename("aoh", 42, None, "all", ".tif")),
+    ("aoh_T42.tif", IUCNFormatFilename("aoh", 42, None, None, ".tif")),
+])
+def test_valid_aoh_filename(filename : Path | str, expected: IUCNFormatFilename) -> None:
+    res = IUCNFormatFilename.of_filename(filename)
+    assert res == expected
+
+@pytest.mark.parametrize("filename, exception", [
+    (None, TypeError),
+    (32, TypeError),
+    ("malformed_filename.tif", ValueError),
+])
+def test_invalid_aoh_filename(filename: Any, exception: type[BaseException]) -> None:
+    with pytest.raises(exception):
+        _ = IUCNFormatFilename.of_filename(filename)
+
+@pytest.mark.parametrize("filename, expected", [
+    (IUCNFormatFilename("aoh", 42, 123, "all", ".tif"), Path("aoh_T42A123_all.tif")),
+    (IUCNFormatFilename("aoh", 42, None, "all", ".tif"), Path("aoh_T42_all.tif")),
+    (IUCNFormatFilename("aoh", 42, 123, None, ".tif"), Path("aoh_T42A123.tif")),
+    (IUCNFormatFilename("aoh", 42, None, None, ".tif"), Path("aoh_T42.tif")),
+])
+def test_valid_build_filename(filename: IUCNFormatFilename, expected: Path) -> None:
+    res = filename.to_path()
+    assert res == expected

--- a/tests/test_species_richness.py
+++ b/tests/test_species_richness.py
@@ -24,7 +24,7 @@ def test_simple_summary_all_pixels_no_overlap(processes) -> None:
                 val = (y * 4) + x
                 data = np.array([[val + 1]])
                 with yg.from_array(data, (x, y + 1), projection) as cell:
-                    cell.to_geotiff(aohs_path / f"{val}_season.tif")
+                    cell.to_geotiff(aohs_path / f"aoh_T{val}A42_season.tif")
 
         result_path = dirpath / "species_richness.tif"
         species_richness(aohs_path, result_path, processes)
@@ -52,7 +52,7 @@ def test_simple_summary_all_pixels_overlap(processes) -> None:
                 val = (y * 4) + x
                 data = np.array([[val + 1]])
                 with yg.from_array(data, (0, 1), projection) as cell:
-                    cell.to_geotiff(aohs_path / f"{val}_season.tif")
+                    cell.to_geotiff(aohs_path / f"aoh_T{val}A42_season.tif")
 
         result_path = dirpath / "species_richness.tif"
         species_richness(aohs_path, result_path, processes)
@@ -74,7 +74,7 @@ def test_seasons_are_merged() -> None:
         for season in ["breeding", "nonbreeding"]:
             data = np.array([[1]])
             with yg.from_array(data, (0, 1), projection) as cell:
-                cell.to_geotiff(aohs_path / f"42_{season}.tif")
+                cell.to_geotiff(aohs_path / f"aoh_T1A42_{season}.tif")
 
         result_path = dirpath / "species_richness.tif"
         species_richness(aohs_path, result_path, 1)
@@ -100,7 +100,7 @@ def test_simple_summary_gaps() -> None:
                 val = (y * 4) + x
                 data = np.array([[val % 2]])
                 with yg.from_array(data, (x, y + 1), projection) as cell:
-                    cell.to_geotiff(aohs_path / f"{val}_season.tif")
+                    cell.to_geotiff(aohs_path / f"aoh_T{val}A42_season.tif")
 
         result_path = dirpath / "species_richness.tif"
         species_richness(aohs_path, result_path, 1)


### PR DESCRIPTION
Move to using a helper class that makes generating and validating IUCN template filenames easier. Technically we go a little beyond the IUCN specification as we need to support people working without assessment IDs (e.g., the plant work that is going on right now as a precursor to them being assessed), and we have the seasonality part too.