### PR TITLE
Move to Yirgacheffe 2.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+## v3.0 (02/06/2026)
+
+### Changed
+
+* Moved to Yirgacheffe 2.0, which isn't a breaking change for this packages APIs, but would break the pipelines built on this AND Yirgacheffe, hence the major version number bump.
+
 ## v2.1.2 (31/03/2026)
 
 ### Added

--- a/aoh/_internal/aoh_binary.py
+++ b/aoh/_internal/aoh_binary.py
@@ -151,7 +151,7 @@ def aohcalc_binary(
     else:
         raise ValueError("Elevation path should be single raster or tuple of min/max raster paths.")
 
-    projection = min_elevation_map.map_projection
+    projection = min_elevation_map.projection
     assert projection is not None
     area_per_pixel = yg.area_raster(projection) if multiply_by_area_per_pixel else 1.0
 

--- a/aoh/_internal/aoh_fractional.py
+++ b/aoh/_internal/aoh_fractional.py
@@ -181,7 +181,7 @@ def aohcalc_fractional(
     else:
         raise ValueError("Elevation path should be single raster or tuple of min/max raster paths.")
 
-    projection = min_elevation_map.map_projection
+    projection = min_elevation_map.projection
     assert projection is not None
     area_per_pixel = yg.area_raster(projection) if multiply_by_area_per_pixel else 1.0
 

--- a/aoh/habitat_process.py
+++ b/aoh/habitat_process.py
@@ -23,8 +23,9 @@ def _enumerate_subset(
 ) -> Set[int]:
     gdal.SetCacheMax(1 * 1024 * 1024 * 1024)
     with yg.read_raster(habitat_path) as habitat_map:
-        blocksize = min(BLOCKSIZE, habitat_map.window.ysize - offset)
-        data = habitat_map.read_array(0, offset, habitat_map.window.xsize, blocksize)
+        width, height = habitat_map.dimensions
+        blocksize = min(BLOCKSIZE, height - offset)
+        data = habitat_map.read_array(0, offset, width, blocksize)
         values = np.unique(data)
         without_nans = values[~np.isnan(values)]
         res = {int(x) for x in without_nans}
@@ -35,7 +36,7 @@ def enumerate_terrain_types(
 ) -> Set[int]:
     gdal.SetCacheMax(1 * 1024 * 1024 * 1024)
     with yg.read_raster(habitat_path) as habitat_map:
-        ysize = habitat_map.window.ysize
+        _, ysize = habitat_map.dimensions
     blocks = range(0, ysize, BLOCKSIZE)
     logger.info("Enumerating habitat classes in raster...")
     with Pool(processes=int(cpu_count() / 2)) as pool:
@@ -123,7 +124,7 @@ def make_single_type_map(
                     # just to ensure that isn't happening.
                     # The 1% check here is probably overly tolerant, but it's enough to catch the
                     # errors that caused this check to be added.
-                    reverted = result.area.reproject(habitat_map.map_projection)
+                    reverted = result.area.reproject(habitat_map.projection)
                     original = habitat_map.area
 
                     if ((abs(original.left - reverted.left) / original.left) > 0.01) or \

--- a/aoh/habitat_process.py
+++ b/aoh/habitat_process.py
@@ -50,19 +50,6 @@ def enumerate_terrain_types(
         pass
     return superset
 
-class VsimemFile:
-    def __init__(self, path):
-        self.path = path
-
-    def __enter__(self):
-        return self.path
-
-    def __exit__(self, *args):
-        try:
-            gdal.Unlink(self.path)
-        except RuntimeError:
-            pass
-
 def make_single_type_map(
     habitat_path: Path,
     pixel_scale: Optional[float],

--- a/aoh/habitat_process.py
+++ b/aoh/habitat_process.py
@@ -80,60 +80,17 @@ def make_single_type_map(
 
     with yg.read_raster(habitat_path) as habitat_map:
         logger.info("Filtering for %s...", habitat_value)
+        filtered_map = habitat_map == habitat_value
 
-        # We use the GDAL in memory file system for all this
-        with VsimemFile(f"/vsimem/filtered_{habitat_value}.tif") as filter_map_path:
-            filtered_map = habitat_map == habitat_value
-            filtered_map.to_geotiff(filter_map_path, parallelism=max_threads)
+        if pixel_scale is not None and target_projection is not None:
+            filtered_map = filtered_map.as_type(yg.DataType.Float32).as_projection(
+                yg.MapProjection(target_projection, pixel_scale, -pixel_scale),
+                yg.ResamplingMethod.Average
+            )
 
-            if pixel_scale is not None and target_projection is not None:
-                reprojected_area = filtered_map.area.reproject(
-                    yg.MapProjection(target_projection, pixel_scale, -pixel_scale)
-                )
-            else:
-                reprojected_area = habitat_map.area
+        filename = f"lcc_{habitat_value}.tif"
+        filtered_map.to_geotiff(output_directory_path / filename, parallelism=True)
 
-            with VsimemFile(f"/vsimem/warped_{habitat_value}.tif") as warped_map_path:
-                logger.info("Projecting %s...", habitat_value)
-                gdal.Warp(
-                    warped_map_path,
-                    filter_map_path,
-                    options=gdal.WarpOptions(
-                        creationOptions=[],
-                        multithread=True,
-                        dstSRS=target_projection,
-                        outputType=gdal.GDT_Float32,
-                        xRes=pixel_scale,
-                        yRes=((0.0 - pixel_scale) if pixel_scale is not None else pixel_scale),
-                        resampleAlg="average",
-                        outputBounds=(reprojected_area.left, reprojected_area.bottom,
-                            reprojected_area.right, reprojected_area.top),
-                        targetAlignedPixels=pixel_scale is not None,
-                        warpOptions=[f'NUM_THREADS={max_threads}'],
-                        warpMemoryLimit=available_mem,
-                        workingType=gdal.GDT_Float32
-                    )
-                )
-
-                logger.info("Saving %s...", habitat_value)
-                filename = f"lcc_{habitat_value}.tif"
-                with yg.read_raster(warped_map_path) as result:
-                    # We had issues whereby original GDAL warp worked okay without needing
-                    # output bounds specified, and then at some point that changed and we were
-                    # losing a lot of the top and bottom of the map. This is a sanity check
-                    # just to ensure that isn't happening.
-                    # The 1% check here is probably overly tolerant, but it's enough to catch the
-                    # errors that caused this check to be added.
-                    reverted = result.area.reproject(habitat_map.projection)
-                    original = habitat_map.area
-
-                    if ((abs(original.left - reverted.left) / original.left) > 0.01) or \
-                        ((abs(original.right - reverted.right) / original.right) > 0.01) or \
-                        ((abs(original.top - reverted.top) / original.top) > 0.01) or \
-                        ((abs(original.bottom - reverted.bottom) / original.bottom) > 0.01):
-                        raise ValueError(f"Area of reprojected map significantly different: {original} vs {reverted}")
-
-                    result.to_geotiff(output_directory_path / filename)
 
 def habitat_process(
     habitat_path: Path,

--- a/aoh/summaries/species_richness.py
+++ b/aoh/summaries/species_richness.py
@@ -32,7 +32,7 @@ def stage_1_worker(
         if raster_paths is None:
             break
         seasonal_rasters = [yg.read_raster(x) for x in raster_paths]
-        binary_species_layer = yg.any(seasonal_rasters).astype(yg.DataType.UInt32)
+        binary_species_layer = yg.any(seasonal_rasters).as_type(yg.DataType.UInt32)
         rasters.append(binary_species_layer)
 
     if rasters:

--- a/aoh/validation/validate_occurences.py
+++ b/aoh/validation/validate_occurences.py
@@ -73,7 +73,7 @@ def process_species(
 
         # The GBIF data is in WGS84, and so we need to map that to a point in the
         # AOH raster projection space
-        points_gdf = wgs84_points_gdf.to_crs(aoh.map_projection.name)
+        points_gdf = wgs84_points_gdf.to_crs(aoh.projection.name)
         clipped_points = gpd.sjoin(points_gdf, species_range, predicate='within', how='inner')
 
         pixel_set = set()
@@ -87,8 +87,8 @@ def process_species(
 
             # These have been converted to the right projection already
             x, y = row.geometry.x, row.geometry.y
-            aligned_x = (x - aoh.area.left) / aoh.map_projection.xstep
-            aligned_y = (y - aoh.area.top) / aoh.map_projection.ystep
+            aligned_x = (x - aoh.area.left) / aoh.projection.xstep
+            aligned_y = (y - aoh.area.top) / aoh.projection.ystep
             floored_aligned_x = math.floor(aligned_x)
             floored_aligned_y = math.floor(aligned_y)
             if (aligned_x - floored_aligned_x) < 0.5:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "aoh"
-version = "2.1.2"
+version = "3.0.0"
 description = "A library for calculating Area of Habitat for species distribution mapping"
 authors = [
     {name = "Michael Dales", email = "mwd24@cam.ac.uk"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
     "psutil",
     "pyproj>=3.4,<4.0",
     "scikit-image>=0.20,<1.0",
-    "yirgacheffe>=1.12.5,<2.0",
+    "yirgacheffe>=2.0,<3.0",
     "zenodo_search",
     "pandas>=2.0,<4.0",
     "gdal[numpy]>=3.8,<3.13",

--- a/tests/test_aoh_binary.py
+++ b/tests/test_aoh_binary.py
@@ -184,13 +184,14 @@ def test_simple_aoh(force_habitat) -> None:
         assert manifest["prevalence"] == 0.5
 
         with yg.read_raster(expected_geotiff_path) as result:
-            assert result.window.xsize == dims[0] / 2
-            assert result.window.ysize == dims[1] / 2
-            data = result.read_array(0, 0, result.window.xsize, result.window.ysize)
+            width, height = result.dimensions
+            assert width == dims[0] / 2
+            assert height == dims[1] / 2
+            data = result.read_array(0, 0, width, height)
         expected = np.array(
-            [1, 0] * ((result.window.xsize * result.window.ysize) // 2)
-        )[:result.window.xsize * result.window.ysize]
-        expected = expected.reshape(result.window.ysize, result.window.xsize)
+            [1, 0] * ((width * height) // 2)
+        )[:width * height]
+        expected = expected.reshape(height, width)
         assert (data == expected).all()
 
 @pytest.mark.parametrize("force_habitat", [True, False])
@@ -325,14 +326,15 @@ def test_simple_aoh_weight(force_habitat) -> None:
         assert manifest["prevalence"] == 0.5
 
         with yg.read_raster(expected_geotiff_path) as result:
-            assert result.window.xsize == dims[0] / 2
-            assert result.window.ysize == dims[1] / 2
-            data = result.read_array(0, 0, result.window.xsize, result.window.ysize)
+            width, height = result.dimensions
+            assert width == dims[0] / 2
+            assert height == dims[1] / 2
+            data = result.read_array(0, 0, width, height)
         expected = np.array(
             [4200000.0, 0.] * \
-            ((result.window.xsize * result.window.ysize) // 2)
-        )[:result.window.xsize * result.window.ysize]
-        expected = expected.reshape(result.window.ysize, result.window.xsize)
+            ((width * height) // 2)
+        )[:width * height]
+        expected = expected.reshape(height, width)
         assert (data == expected).all()
 
 @pytest.mark.parametrize("force_habitat", [True, False])
@@ -398,12 +400,13 @@ def test_simple_aoh_multiple_habitats(force_habitat) -> None:
         assert math.isclose(manifest["prevalence"], 1/2)
 
         with yg.read_raster(expected_geotiff_path) as result:
-            assert result.window.xsize == 10
-            assert result.window.ysize == 6
+            width, height = result.dimensions
+            assert width == 10
+            assert height == 6
             data = result.read_array(0, 0, 10, 6)
 
         expected = np.array([1, 0, 0, 1, 1, 0, 0, 1, 1, 0] * 6)
-        expected = expected.reshape(result.window.ysize, result.window.xsize)
+        expected = expected.reshape(height, width)
         assert np.isclose(data, expected).all()
 
 

--- a/tests/test_aoh_fractional.py
+++ b/tests/test_aoh_fractional.py
@@ -187,10 +187,11 @@ def test_simple_aoh(force_habitat) -> None:
         assert manifest["prevalence"] == 0.5
 
         with yg.read_raster(expected_geotiff_path) as result:
-            assert result.window.xsize == dims[0] / 2
-            assert result.window.ysize == dims[1] / 2
-            data = result.read_array(0, 0, result.window.xsize, result.window.ysize)
-        expected = np.full((result.window.ysize, result.window.xsize), 0.5)
+            width, height = result.dimensions
+            assert width == dims[0] / 2
+            assert height == dims[1] / 2
+            data = result.read_array(0, 0, width, height)
+        expected = np.full((height, width), 0.5)
         assert (data == expected).all()
 
 @pytest.mark.parametrize("force_habitat", [True, False])
@@ -331,10 +332,11 @@ def test_simple_aoh_weights(force_habitat) -> None:
         assert manifest["prevalence"] == 0.5
 
         with yg.read_raster(expected_geotiff_path) as result:
-            assert result.window.xsize == dims[0] / 2
-            assert result.window.ysize == dims[1] / 2
-            data = result.read_array(0, 0, result.window.xsize, result.window.ysize)
-        expected = np.full((result.window.ysize, result.window.xsize), 0.5 * pixel_area)
+            width, height = result.dimensions
+            assert width == dims[0] / 2
+            assert height == dims[1] / 2
+            data = result.read_array(0, 0, width, height)
+        expected = np.full((height, width), 0.5 * pixel_area)
         assert (data == expected).all()
 
 @pytest.mark.parametrize("force_habitat", [True, False])
@@ -403,8 +405,9 @@ def test_simple_aoh_multiple_habitats(force_habitat) -> None:
         assert math.isclose(manifest["prevalence"], 2/3)
 
         with yg.read_raster(expected_geotiff_path) as result:
-            assert result.window.xsize == 10
-            assert result.window.ysize == 6
+            width, height = result.dimensions
+            assert width == 10
+            assert height == 6
             data = result.read_array(0, 0, 10, 6)
         expected = np.full((6, 10), 2/3)
         assert np.isclose(data, expected).all()

--- a/tests/test_habitat_process.py
+++ b/tests/test_habitat_process.py
@@ -24,7 +24,7 @@ def generate_habitat_map(
         [],
     )
     dataset.SetGeoTransform((-180.0, 360/width, 0.0, 90, 0.0, -180/height))
-    dataset.SetProjection("WGS84")
+    dataset.SetProjection("epsg:4326")
     band = dataset.GetRasterBand(1)
     band.WriteArray(data, 0, 0)
     dataset.Close()
@@ -80,7 +80,7 @@ def test_rescale_make_single_map() -> None:
         make_single_type_map(
             habitat_path,
             180.0 / 10.0, # Scale down by half
-            None,
+            "epsg:4326",
             tmp,
             1,
             100,

--- a/tests/test_habitat_process.py
+++ b/tests/test_habitat_process.py
@@ -60,9 +60,9 @@ def test_simple_make_single_map() -> None:
 
         with  yg.read_raster(habitat_path) as original:
             with yg.read_raster(expected_result_path) as result:
-                assert result.window == original.window
-                original_data = original.read_array(0, 0, original.window.xsize, original.window.ysize)
-                result_data = result.read_array(0, 0, result.window.xsize, result.window.ysize)
+                assert result.dimensions == original.dimensions
+                original_data = original.read_array(0, 0, original.dimensions[0], original.dimensions[1])
+                result_data = result.read_array(0, 0, result.dimensions[0], result.dimensions[1])
 
         # We did not resize or projection, so should be just a simple map
         expected_data = (original_data == 100).astype(int)
@@ -90,10 +90,10 @@ def test_rescale_make_single_map() -> None:
 
         with  yg.read_raster(habitat_path) as original:
             with yg.read_raster(expected_result_path) as result:
-                assert result.window.xsize == original.window.xsize / 2
-                assert result.window.ysize == original.window.ysize / 2
-                original_data = original.read_array(0, 0, original.window.xsize, original.window.ysize)
-                result_data = result.read_array(0, 0, result.window.xsize, result.window.ysize)
+                assert result.dimensions[0] == original.dimensions[0] / 2
+                assert result.dimensions[1] == original.dimensions[1] / 2
+                original_data = original.read_array(0, 0, original.dimensions[0], original.dimensions[1])
+                result_data = result.read_array(0, 0, result.dimensions[0], result.dimensions[1])
 
         binary_original_data = (original_data == 100).astype(int)
         expected_data = binary_original_data.reshape(10, 2, 20, 2).mean(axis=(1, 3))

--- a/tests/test_species_richness.py
+++ b/tests/test_species_richness.py
@@ -30,7 +30,7 @@ def test_simple_summary_all_pixels_no_overlap(processes) -> None:
         species_richness(aohs_path, result_path, processes)
 
         with yg.read_raster(result_path) as result:
-            assert result.window == yg.Window(0, 0, 4, 4)
+            assert result.dimensions == (4, 4)
             assert result.area == yg.Area(0, 4, 4, 0, projection)
             expected = np.ones((4,4))
             result_data = result.read_array(0, 0, 4, 4)
@@ -58,7 +58,7 @@ def test_simple_summary_all_pixels_overlap(processes) -> None:
         species_richness(aohs_path, result_path, processes)
 
         with yg.read_raster(result_path) as result:
-            assert result.window == yg.Window(0, 0, 1, 1)
+            assert result.dimensions == (1, 1)
             assert result.area == yg.Area(0, 1, 1, 0, projection)
             result_data = result.read_array(0, 0, 1, 1)[0][0]
             assert result_data == (4 * 4)
@@ -80,7 +80,7 @@ def test_seasons_are_merged() -> None:
         species_richness(aohs_path, result_path, 1)
 
         with yg.read_raster(result_path) as result:
-            assert result.window == yg.Window(0, 0, 1, 1)
+            assert result.dimensions == (1, 1)
             assert result.area == yg.Area(0, 1, 1, 0, projection)
             result_data = result.read_array(0, 0, 1, 1)[0][0]
             assert result_data == 1
@@ -106,7 +106,7 @@ def test_simple_summary_gaps() -> None:
         species_richness(aohs_path, result_path, 1)
 
         with yg.read_raster(result_path) as result:
-            assert result.window == yg.Window(0, 0, 4, 4)
+            assert result.dimensions == (4, 4)
             assert result.area == yg.Area(0, 4, 4, 0, projection)
             expected = np.array([
                 [0, 1, 0, 1],


### PR DESCRIPTION
The release of Yirgacheffe 2.0 had some useful improvements but also some breaking API changes, so this 3.0 release of AOH Calculator doesn't have any API changes itself, but because the pipelines in which it is used also depend on Yirgacheffe, I had to do a major version increment to stop them automatically picking up newer Yirgacheffe and breaking.

The main change here is that Yirgacheffe 2.0 supports raster reprojection as an operator, so all the GDAL warp code could be removed in the habitat processing script.